### PR TITLE
feat: Add inbox username to email

### DIFF
--- a/EmailReader/Email.cs
+++ b/EmailReader/Email.cs
@@ -11,5 +11,6 @@ namespace EmailReader
         public string? Body { get; set; }
         public DateTime Date { get; set; }
         public string[]? Attachments { get; set; }
+        public string? Inbox { get; set; }
     }
 }

--- a/EmailReader/EmailReaderService.cs
+++ b/EmailReader/EmailReaderService.cs
@@ -77,7 +77,8 @@ namespace EmailReader
                             Subject = message.Subject,
                             Body = message.TextBody,
                             Date = message.Date.UtcDateTime,
-                            Attachments = message.Attachments.Select(a => a.ContentDisposition?.FileName ?? "unknown").ToArray()
+                            Attachments = message.Attachments.Select(a => a.ContentDisposition?.FileName ?? "unknown").ToArray(),
+                            Inbox = imapConfig.Username
                         };
 
                         await _elasticClient.IndexAsync(email, "emails", email.Id, cancellationToken);

--- a/EmailReader/elasticsearch_template.json
+++ b/EmailReader/elasticsearch_template.json
@@ -64,6 +64,9 @@
       },
       "attachments": {
         "type": "text"
+      },
+      "inbox": {
+        "type": "keyword"
       }
     }
   }


### PR DESCRIPTION
Adds the inbox username to the email object and the Elasticsearch index template.

This is to avoid ID collisions when importing from multiple inboxes.